### PR TITLE
Enforce 1 request per second to the API

### DIFF
--- a/aweber_api/oauth_application.php
+++ b/aweber_api/oauth_application.php
@@ -76,6 +76,11 @@ class OAuthApplication implements AWeberOAuthAdapter {
     public $consumerSecret = false;
 
     /**
+     * @var int The timestamp of the last request to be mindful of the AWeber rate limit
+     */
+    public $lastRequestTime = 0;
+
+    /**
      * __construct
      *
      * Create a new OAuthApplication, based on an OAuthServiceProvider
@@ -115,6 +120,12 @@ class OAuthApplication implements AWeberOAuthAdapter {
                 }
             }
         }
+
+        // Check if rate limit is in effect
+        while ((microtime(true) - $this->lastRequestTime) <= 1) {
+            usleep(100000); // Wait 1/10th second and check again.
+        }
+        $this->lastRequestTime = microtime(true);
 
         $response = $this->makeRequest($method, $url, $data);
         if (!empty($options['return'])) {
@@ -235,9 +246,9 @@ class OAuthApplication implements AWeberOAuthAdapter {
     /**
      * _addParametersToUrl
      *
-     * Adds the parameters in associative array $data to the 
+     * Adds the parameters in associative array $data to the
      * given URL
-     * @param String $url       URL 
+     * @param String $url       URL
      * @param array $data       Parameters to be added as a query string to
      *      the URL provided
      * @access protected

--- a/tests/OAuthApplicationTest.php
+++ b/tests/OAuthApplicationTest.php
@@ -302,4 +302,14 @@ class TestOAuthAppliation extends PHPUnit_Framework_TestCase {
         $this->assertEquals($data,0);
     }
 
+    public function testRequestsObeyAWeberRateLimit() {
+        $this->adapter = get_mock_adapter();
+        $url = '/accounts/1/lists/303449/subscribers?email=someone%40example.com&ws.show=total_size';
+        $data = $this->adapter->request('GET', $url);
+        $time1 = microtime(true);
+        $url = '/accounts/1/lists/303449/subscribers?email=someone%40example.com&ws.show=total_size';
+        $data = $this->adapter->request('GET', $url);
+        $time2 = microtime(true);
+        $this->assertGreaterThanOrEqual(1, ($time2 - $time1));
+    }
 }


### PR DESCRIPTION
This could be improved to track request times per AccessToken. This is
helpful for applications running long-running background tasks in a
single process such as contact synchronization.

---

Per [the AWeber TOS](https://labs.aweber.com/docs/tos#access) applications should not exceed 60 requests per minute per authenticated user and applications should be designed to respect this limit. This pull request is the simplest way to ensure compliance with that limit.

It could be improved to track the last request per accessToken or at least be option... I'd prefer feedback and direction before investing too much time into perfecting a particular strategy though. Keep in mind this will only work on long-running synchronous background tasks. Because PHP runs each script execution in isolation, this PR won't really help track the rate limit across multiple simultaneous PHP executions (i.e., API calls done during client requests on a website). In our use-case, we're running each user's AWeber synchronization in a gearman worker thread, so this solution works fine.
