### PR TITLE
Fix composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "issues": "https://github.com/aweber/AWeber-API-PHP-Library"
     },
     "autoload": {
-        "psr-4": {
-            "": "aweber_api/"
-        }
+        "files": [
+            "aweber_api/aweber_api.php"
+        ]
     }
 }


### PR DESCRIPTION
Running `composer require aweber/aweber` does not correctly autoload the main file as the project structure doesn't follow psr-4 standards.. 
