### PR TITLE
fix readResponse if response is not array

### DIFF
--- a/aweber_api/aweber.php
+++ b/aweber_api/aweber.php
@@ -120,12 +120,15 @@ class AWeberAPIBase {
      */
     protected function readResponse($response, $url) {
         $this->adapter->parseAsError($response);
-        if (!empty($response['id']) || !empty($response['broadcast_id'])) {
-            return new AWeberEntry($response, $url, $this->adapter);
-        } else if (array_key_exists('entries', $response)) {
-            return new AWeberCollection($response, $url, $this->adapter);
+        if (is_array($response)) {
+            if (!empty($response['id']) || !empty($response['broadcast_id'])) {
+                return new AWeberEntry($response, $url, $this->adapter);
+            } else if (array_key_exists('entries', $response)) {
+                return new AWeberCollection($response, $url, $this->adapter);
+            }
         }
-        return false;
+
+        return $response;
     }
 }
 


### PR DESCRIPTION
**FIX:** if response is not array return the response (integer in case of total size)

**DETAILS:**
when requesting for a list total size with a direct URL:
`https://api.aweber.com/1.0/accounts/{$account_id}/lists/{$list_id}/subscribers?ws.show=total_size&ws.op=find&subscription_method=api`
the response is an integer.

However the public [loadFromUrl](https://github.com/florentroques/AWeber-API-PHP-Library/blob/c355590c38fdeb2ba2eb843273673abc115b43ac/aweber_api/aweber.php#L103) method doesn't work because the protected [readResponse](https://github.com/florentroques/AWeber-API-PHP-Library/blob/c355590c38fdeb2ba2eb843273673abc115b43ac/aweber_api/aweber.php#L121) method works only with array like responses.

This pull request fixes it by adding a check on response type.
